### PR TITLE
M4rkmckenna/bugfix/open port forward aled

### DIFF
--- a/common/src/test/java/brooklyn/networking/util/TestEntityImpl.java
+++ b/common/src/test/java/brooklyn/networking/util/TestEntityImpl.java
@@ -22,7 +22,8 @@ package brooklyn.networking.util;
 
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.AbstractApplication;
-import org.apache.brooklyn.core.entity.AbstractEntity;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * @author m4rkmckenna on 11/12/2015.
@@ -35,6 +36,6 @@ public class TestEntityImpl extends AbstractApplication implements TestEntity {
 
     @Override
     public void addLocation(final Location location) {
-        sensors().emit(AbstractEntity.LOCATION_ADDED, location);
+        super.addLocations(ImmutableList.of(location));
     }
 }


### PR DESCRIPTION
@m4rkmckenna here are a few more tests and improvements for the advanced networking port forwarding stuff. Can you please review and, if appropriate, merge into your branch so it goes in the PR?

A couple of extra comments:
- I like functional tests to have big timeouts, in case something runs slow (e.g. not just 500ms). In jenkins (particularly cloudbees and apache shared infrastructure), we've seen delays of seconds some times.
- The mock PortForwarder is quite like a stub, given that the answer method has behaviour. But no strong feelings. Using the mock saves us from implementing all the other methods.
- The test fails periodically due to a concurrency bug in Brooklyn, which I'm testing a fix for. If you try to write many sensor values concurrently on an entity, then sometimes it loses some! There's be a PR in brooklyn for that shortly.
